### PR TITLE
Update compliance data in orderProduct endpoint

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps Partner API
-  version: '0.9.3'
+  version: '0.9.4'
   description: |
     The Vipps Partner API lets partners, banks and large corporations manage
     their merchants (for example, submit product orders on behalf of their
@@ -395,13 +395,9 @@ components:
               description: Password to log in on the test website
               example: test-password
         complianceData:
-          x-nullable: true
-          nullable: true
           type: object
           properties:
             giftCard:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - isSalesPercentageLessThanTen
@@ -417,8 +413,6 @@ components:
                   description: For how long is the gift card valid after purchase
                   example: 3 years
             membership:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -430,11 +424,9 @@ components:
                   example: about 25%
                 periodDistribution:
                   type: string
-                  description: Distribution of memberships in different periods that is beeing sold
+                  description: Distribution of memberships in different periods that is being sold
                   example: 50% yearly 20% monthly
             subscription:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -446,11 +438,9 @@ components:
                   example: about 25%
                 periodDistribution:
                   type: string
-                  description: Distribution of subscriptions in different periods that is beeing sold
+                  description: Distribution of subscriptions in different periods that is being sold
                   example: 50% yearly 20% monthly
             course:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -476,13 +466,10 @@ components:
                   default: false
                   example: false
                 onlineAccessableTime:
-                  x-nullable: true
                   type: string
                   description: How long after purchase does a user have access to the course
                   example: for 3 months
             ticket:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -497,8 +484,6 @@ components:
                   description: How long in advance of an event it is common to order and pay for a ticket
                   example: 10 weeks
             rent:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -518,8 +503,6 @@ components:
                   description: How long the average rental period is
                   example: 3 weeks
             prepaidServices:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -534,8 +517,6 @@ components:
                   description: How long in advance of a service it is common to order and pay
                   example: 10 weeks
             donation:
-              x-nullable: true
-              nullable: true
               type: object
               required:
                 - acceptsDonation

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps Partner API
-  version: '0.9.4'
+  version: '0.9.5'
   description: |
     The Vipps Partner API lets partners, banks and large corporations manage
     their merchants (for example, submit product orders on behalf of their
@@ -78,7 +78,7 @@ paths:
                       timeBeforeOrder: 10 days
                       period: once every 6 week
                       isOnlineCourseOffered: true
-                      onlineAccessableTime: for 3 months
+                      onlineAccessibleTime: for 3 months
                     ticket:
                       turnoverShare: about 25%
                       prepurchaseTime: 10 weeks
@@ -465,7 +465,7 @@ components:
                   description: True if there are online courses offered
                   default: false
                   example: false
-                onlineAccessableTime:
+                onlineAccessibleTime:
                   type: string
                   description: How long after purchase does a user have access to the course
                   example: for 3 months

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps Partner API
-  version: '0.9.2'
+  version: '0.9.3'
   description: |
     The Vipps Partner API lets partners, banks and large corporations manage
     their merchants (for example, submit product orders on behalf of their
@@ -65,7 +65,7 @@ paths:
                     testWebsitePassword: test-password
                   complianceData:
                     giftCard:
-                      salesPercentage: GTE_10
+                      isSalesPercentageLessThanTen: false
                       validityDuration: 3 years
                     membership:
                       turnoverShare: about 25%
@@ -77,7 +77,7 @@ paths:
                       turnoverShare: about 25%
                       timeBeforeOrder: 10 days
                       period: once every 6 week
-                      online: 'YES'
+                      isOnlineCourseOffered: true
                       onlineAccessableTime: for 3 months
                     ticket:
                       turnoverShare: about 25%
@@ -90,7 +90,7 @@ paths:
                       turnoverShare: about 25%
                       prepurchaseTime: 10 weeks
                     donation:
-                      acceptsDonations: 'YES'                      
+                      acceptDonations: true                      
       responses:
         '200':
           description: OK
@@ -395,26 +395,30 @@ components:
               description: Password to log in on the test website
               example: test-password
         complianceData:
+          x-nullable: true
+          nullable: true
           type: object
           properties:
             giftCard:
+              x-nullable: true
+              nullable: true
               type: object
               required:
-                - salesPercentage
-                - validityDuration              
+                - isSalesPercentageLessThanTen
+                - validityDuration
               properties:
-                salesPercentage:
-                  type: string
-                  enum:
-                    - LT_10
-                    - GTE_10
-                  description: How much percentage gift card sales consists of
-                  example: GTE_10
+                isSalesPercentageLessThanTen:
+                  type: boolean
+                  default: false
+                  description: How much percentage giftcard sales consits of. Either Less than 10% or 10% and more
+                  example: false
                 validityDuration:
                   type: string
                   description: For how long is the gift card valid after purchase
                   example: 3 years
             membership:
+              x-nullable: true
+              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -426,9 +430,11 @@ components:
                   example: about 25%
                 periodDistribution:
                   type: string
-                  description: Distribution of memberships in different periods that is being sold
+                  description: Distribution of memberships in different periods that is beeing sold
                   example: 50% yearly 20% monthly
             subscription:
+              x-nullable: true
+              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -440,9 +446,11 @@ components:
                   example: about 25%
                 periodDistribution:
                   type: string
-                  description: Distribution of subscriptions in different periods that is being sold
+                  description: Distribution of subscriptions in different periods that is beeing sold
                   example: 50% yearly 20% monthly
             course:
+              x-nullable: true
+              nullable: true
               type: object
               required:
                 - turnoverShare
@@ -462,23 +470,23 @@ components:
                   type: string
                   description: How long the duration of a course usually is
                   example: once every 6. week
-                online:
-                  type: string
-                  enum:
-                    - 'YES'
-                    - 'NO'
-                  description: YES if there are online courses offered
-                  example: 'YES'
+                isOnlineCourseOffered:
+                  type: boolean
+                  description: True if there are online courses offered
+                  default: false
+                  example: false
                 onlineAccessableTime:
+                  x-nullable: true
                   type: string
                   description: How long after purchase does a user have access to the course
                   example: for 3 months
             ticket:
+              x-nullable: true
+              nullable: true
               type: object
-              description: Only required if the sale unit will sell tickets.
               required:
                 - turnoverShare
-                - timeBeforeOrder
+                - prepurchaseTime
               properties:
                 turnoverShare:
                   type: string
@@ -489,8 +497,9 @@ components:
                   description: How long in advance of an event it is common to order and pay for a ticket
                   example: 10 weeks
             rent:
+              x-nullable: true
+              nullable: true
               type: object
-              description: Only required if the sale unit will do rentals.
               required:
                 - turnoverShare
                 - prepurchaseTime
@@ -509,8 +518,9 @@ components:
                   description: How long the average rental period is
                   example: 3 weeks
             prepaidServices:
+              x-nullable: true
+              nullable: true
               type: object
-              description: Only required if the sale unit will do prepaid services
               required:
                 - turnoverShare
                 - prepurchaseTime
@@ -524,21 +534,17 @@ components:
                   description: How long in advance of a service it is common to order and pay
                   example: 10 weeks
             donation:
+              x-nullable: true
+              nullable: true
               type: object
-              description: Only required if the sale unit will receive donations
               required:
-                - acceptsDonations   
+                - acceptsDonation
               properties:
-                acceptsDonations:
-                  type: string
-                  enum:
-                    - 'YES'
-                    - 'NO'
-                  x-enum-varnames:
-                    - 'YES'
-                    - 'NO'
-                  description: YES if merchant will receive donations through Vipps
-                  example: 'YES'                   
+                acceptsDonation:
+                  type: boolean
+                  description: true if merchant will receive donation through Vipps
+                  default: false
+                  example: false                   
     ProductOrderResponse:
       title: Product Order Response
       type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -65,12 +65,10 @@ paths:
                     testWebsitePassword: test-password
                   complianceData:
                     giftCard:
-                      salesPercentage: TEN_OR_MORE
-                      turnoverShare: about 25%
+                      salesPercentage: GTE_10
                       validityDuration: 3 years
                     membership:
                       turnoverShare: about 25%
-                      validFor: YEAR
                       periodDistribution: 50% yearly 20% monthly
                     subscription:
                       turnoverShare: about 25%
@@ -88,6 +86,11 @@ paths:
                       turnoverShare: about 25%
                       prepurchaseTime: 15 days
                       averageRentalDuration: 3 weeks
+                    prepaidServices:
+                      turnoverShare: about 25%
+                      prepurchaseTime: 10 weeks
+                    donation:
+                      acceptsDonations: 'YES'                      
       responses:
         '200':
           description: OK
@@ -396,18 +399,17 @@ components:
           properties:
             giftCard:
               type: object
+              required:
+                - salesPercentage
+                - validityDuration              
               properties:
                 salesPercentage:
                   type: string
                   enum:
-                    - UNDER_TEN
-                    - TEN_OR_MORE
+                    - LT_10
+                    - GTE_10
                   description: How much percentage gift card sales consists of
-                  example: TEN_OR_MORE
-                turnoverShare:
-                  type: string
-                  description: Estimated turnover share of gift card sales in percentage
-                  example: about 25%
+                  example: GTE_10
                 validityDuration:
                   type: string
                   description: For how long is the gift card valid after purchase
@@ -416,23 +418,12 @@ components:
               type: object
               required:
                 - turnoverShare
-                - validFor
                 - periodDistribution
               properties:
                 turnoverShare:
                   type: string
                   description: Estimated turnover share of membership sales in percentage
                   example: about 25%
-                validFor:
-                  type: string
-                  enum:
-                    - YEAR
-                    - CALENDER_YEAR
-                  description: |
-                    How long is the membership valid for
-                     - YEAR: The membership is valid for 1 year (ca. 365 days) from the day of payment.
-                     - CALENDER_YEAR: The membership is valid until end of this year.
-                  example: YEAR
                 periodDistribution:
                   type: string
                   description: Distribution of memberships in different periods that is being sold
@@ -517,6 +508,37 @@ components:
                   type: string
                   description: How long the average rental period is
                   example: 3 weeks
+            prepaidServices:
+              type: object
+              description: Only required if the sale unit will do prepaid services
+              required:
+                - turnoverShare
+                - prepurchaseTime
+              properties:
+                turnoverShare:
+                  type: string
+                  description: Estimated turnover share of prepaid services sales in percentage
+                  example: about 25%
+                prepurchaseTime:
+                  type: string
+                  description: How long in advance of a service it is common to order and pay
+                  example: 10 weeks
+            donation:
+              type: object
+              description: Only required if the sale unit will receive donations
+              required:
+                - acceptsDonations   
+              properties:
+                acceptsDonations:
+                  type: string
+                  enum:
+                    - 'YES'
+                    - 'NO'
+                  x-enum-varnames:
+                    - 'YES'
+                    - 'NO'
+                  description: YES if merchant will receive donations through Vipps
+                  example: 'YES'                   
     ProductOrderResponse:
       title: Product Order Response
       type: object


### PR DESCRIPTION
Allow partners to order product for their merchants through the orderProduct endpoint. Partners now need to data about donations and pre-paid services if the merchants do those. Few other compliance data has been simplified.