### PR TITLE
Get API keys by MSN

### DIFF
--- a/vipps-partner-api.md
+++ b/vipps-partner-api.md
@@ -5,7 +5,7 @@ about their merchants and their sale units.
 
 API version: 1.0.0.
 
-Document version 1.5.2.
+Document version 1.6.0.
 
 ## Table of contents
 
@@ -18,6 +18,7 @@ Document version 1.5.2.
 * [Get information about a sale unit based on MSN](#get-information-about-a-sale-unit-based-on-msn)
   * [Future improvements](#future-improvements)
   * [In the meantime](#in-the-meantime)
+* [Get API keys based on MSN](#get-api-keys-based-on-msn)
 * [Submit a product order for a merchant](#submit-a-product-order-for-a-merchant)
   * [Future improvements](#future-improvements)
 * [Future plans for this API](#future-plans-for-this-api)
@@ -163,6 +164,31 @@ Until more functionality is available in this API, there are some workarounds:
 
 * [How can I check if I have "reserve capture" or "direct capture"?](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api-faq.md#how-can-i-check-if-i-have-reserve-capture-or-direct-capture)
 * [How can I check if I have skipLandingPage activated?](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api-faq.md#how-can-i-check-if-i-have-skiplandingpage-activated)
+
+## Get API keys based on MSN
+
+Partners can only use the partner keys when the merchant is not able to access them.
+Partners that are not able to hide or protect the partner keys from merchants
+must use the merchant's own API keys. This endpoint lets the partner retrieve
+the merchant's own API keys for a specific MSN.
+
+`GET:/saleunits/{msn}/api-keys`
+
+The response (see the Swagger spec for details):
+
+```
+{
+  "msn": 123456,
+  "client_id": "fb492b5e-7907-4d83-ba20-c7fb60ca35de",
+  "client_secret": "Y8Kteew6GE2ZmeycEt6egg==",
+  "Vipps-Subscription-Key": "0f14ebcab0ec4b29ae0cb90d91b4a84a"
+}
+```
+
+The API only returns the primary API key.
+It is not possible to regenerate keys using the API.
+If the MSN is not registered with the partner making the API call the response
+will be `HTTP 404 Not Found`, as we do not "leak" information.
 
 ## Submit a product order for a merchant
 

--- a/vipps-partner-api.md
+++ b/vipps-partner-api.md
@@ -5,7 +5,7 @@ about their merchants and their sale units.
 
 API version: 1.0.0.
 
-Document version 1.6.0.
+Document version 1.6.1.
 
 ## Table of contents
 
@@ -201,6 +201,13 @@ This is a new API, so feedback is welcome!
 Please try to use GitHub's
 [issue](https://github.com/vippsas/vipps-partner-api/issues)
 functionality, so we can avoid multiple parallel discussions in various channels.
+
+**Please note:** This endpoint can only be used for merchants that already have
+a customer relationship with Vipps. If the merchant does no have this,
+a merchant agreement must first be established by the merchant on
+[portal.vipps.no](https://portal.vipps.no).
+We are aware that this is not ideal, and we are working on simplifying this,
+but we wanted to make this endpoint available sooner rather than later.
 
 [`POST:/products/orders`](https://vippsas.github.io/vipps-partner-api/#/Vipps%20Product%20Orders/order-product)
 


### PR DESCRIPTION
Draft for today's meeting. 🔥

Problem: Partner keys do not work with the Vipps Login API. Partners that use partner keys today have to change to the merchant's own API keys to use Vipps Login API, as that API uses standard OIDC authentication, and not the same authentication as other Vipps APIs.

Benefits:
- Partners can retrieve API keys for all MSNs registered with that partner
- The merchant's API keys are valid for all Vipps APIs, including Vipps Login API (OIDC)

Drawbacks:
- If a merchant wants to prevent a partner from acting on behalf of it, it it not enough to unregister the partner for a MSN. Since the partner already has the merchant's Owen API keys, the merchant's API keys must be regenerated.
- A partner can make API calls with the merchant's API keys without the MSN header that is required when using partner keys.

The alternative is to _in some way_ make it possible top use partner keys with the Vipps Login API. It may not be super elegant on the backend, but simple seen from the outside.

---

The current process for changing partners: https://github.com/vippsas/vipps-partner#how-to-change-partners-for-a-merchant
